### PR TITLE
Add WardsAuto 2025 interior ranking card

### DIFF
--- a/test.html
+++ b/test.html
@@ -46,7 +46,17 @@ footer{font-size:.8rem;text-align:center;color:var(--muted);padding:24px 5vw}
 
 <main id="news-container">
 
-<!-- ===== 実在確認できた 4 件 ===== -->
+<!-- ===== 実在確認できた 5 件 ===== -->
+<div class="card" data-country="USA" data-keywords="快適" data-date="2025-04-25">
+  <img src="https://i.gaw.to/content/photos/66/31/663162-les-10-meilleurs-habitacles-de-2025-selon-wardsauto.jpeg" alt="WardsAuto interior awards">
+  <div class="card-content">
+    <h3>WardsAutoが2025年ベスト内装を選出</h3>
+    <p>米誌が快適性で10車を評価。<span class="meta">2025-04-25 | USA</span></p>
+    <p class="meta">選定理由：快適内装評価</p>
+    <a class="meta" href="https://www.guideautoweb.com/en/articles/78366/top-10-best-car-interiors-of-2025-according-to-wardsauto/" target="_blank">記事へ</a>
+    <div class="tags"><span class="tag">快適</span><span class="tag">USA</span></div>
+  </div>
+</div>
 <div class="card" data-country="Japan" data-keywords="熱マネ,快適" data-date="2025-06-02">
   <img src="https://bestcarweb.jp/mwimgs/0/4/1200/img_04f896630f9e319efa0c3abb5a1f612f.jpg" alt="Toyota multi-zone AC test">
   <div class="card-content">


### PR DESCRIPTION
## Summary
- add WardsAuto's top 10 interiors 2025 article card

## Testing
- `curl -s -L -H 'User-Agent: Mozilla/5.0' 'https://www.guideautoweb.com/en/articles/78366/top-10-best-car-interiors-of-2025-according-to-wardsauto/' | grep -o '"published":"[^"]*"'`
- `curl -I 'https://i.gaw.to/content/photos/66/31/663162-les-10-meilleurs-habitacles-de-2025-selon-wardsauto.jpeg'`


------
https://chatgpt.com/codex/tasks/task_e_68b0075dde3883268d12bb0457c9c14d